### PR TITLE
Added 1 malware domain, 7 spamdex site domains

### DIFF
--- a/bot-public-list.txt
+++ b/bot-public-list.txt
@@ -1,3 +1,11 @@
+ducatiperformanceparts.net
+mytravelsite.info
+badgerme.co
+newyearnewyear.com
+1-musica.dcdcapital.com
+nesaraeurope.info
+nodaktwinsfan.com
+5fkitchen.com
 findercarphotos.com
 adanih.com
 diedesign.info


### PR DESCRIPTION
The URL used by the bot links to a malware infected page under the following domain:
ducatiperformanceparts.net

**MALWARE URL** for reference:  www.ducatiperformanceparts.net/photographyzym/facehugger-halcyon

All of these domains listed below are "Moen Quinn kitchen faucet" spamdex sites that use either "moen-quinn-kitchen-faucet.html" or "moen-quinn-kitchen-faucet" in the URL:

mytravelsite.info
badgerme.co
newyearnewyear.com
1-musica.dcdcapital.com
nesaraeurope.info
nodaktwinsfan.com
5fkitchen.com